### PR TITLE
File_url POST parameter should be transmitted in the body

### DIFF
--- a/src/HelloSignApi/Internal/HttpContentExtensions.cs
+++ b/src/HelloSignApi/Internal/HttpContentExtensions.cs
@@ -72,7 +72,7 @@ namespace HelloSignApi
                 {
                     if (file.RemotePath != null)
                     {
-                        content.AddParameter(log, $"file_url[{i}]", file.RemotePath.ToString(), file.FileName);
+                        content.AddParameter(log, $"file_url[{i}]", file.RemotePath.ToString());
                     }
 #if !PORTABLE
                     else if (file.LocalPath != null)

--- a/src/HelloSignApi/Requests/PendingFile.cs
+++ b/src/HelloSignApi/Requests/PendingFile.cs
@@ -16,7 +16,7 @@ namespace HelloSignApi.Requests
         /// Initializes a new instance of the <see cref="PendingFile" /> class.
         /// </summary>
         /// <param name="remoteFilePath">The remote file path.</param>
-        /// <param name="fileName">Name of the file.</param>
+		/// <param name="fileName">Obsolete. Has no bearing on the name of the remote file.</param>
         /// <exception cref="ArgumentNullException">remoteFilePath</exception>
         /// <exception cref="ArgumentException">Only remote http/https file is supported.</exception>
         public PendingFile(Uri remoteFilePath, string fileName = null)
@@ -27,7 +27,6 @@ namespace HelloSignApi.Requests
                 string.Equals(remoteFilePath.Scheme, "https"))
             {
                 RemotePath = remoteFilePath;
-                FileName = fileName ?? remoteFilePath.AbsolutePath.Split(new char[] { '/' }, StringSplitOptions.RemoveEmptyEntries).LastOrDefault();
             }
             else
             {


### PR DESCRIPTION
HelloSign treats any data attached as an additional multipart data stream as content to be rendered, even if the Form Name is file_url[0].  Rather than download the remote file, HelloSign just renders the link itself as the document to be signed.

The official API treats file_url[n] as just another POST parameter, including it alongside _title_ and _message_.

This change marks the fileName parameter of PendingFile obsolete when used with a Uri, and uses the non-filenaming AddParameter overload to add file_url to the POST.